### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,7 +1,8 @@
 name: Lint Commit Messages
+permissions:
+  contents: read
 
 on:
-  push:
     branches:
       - main
       - master


### PR DESCRIPTION
Potential fix for [https://github.com/GabrielNat1/RPG-Eldoria/security/code-scanning/1](https://github.com/GabrielNat1/RPG-Eldoria/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. For this workflow, which only checks out code and lints commit messages, `contents: read` is sufficient. The `permissions` key should be added at the top level of the workflow file (just after the `name` field and before `on:`), so it applies to all jobs in the workflow. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
